### PR TITLE
feat: アニメの登録テスト

### DIFF
--- a/src/test/java/com/example/demo/mapper/AnimeMapperTests.java
+++ b/src/test/java/com/example/demo/mapper/AnimeMapperTests.java
@@ -2,6 +2,7 @@ package com.example.demo.mapper;
 
 import com.example.demo.entity.Anime;
 import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.core.api.dataset.ExpectedDataSet;
 import com.github.database.rider.spring.api.DBRider;
 import org.junit.jupiter.api.Test;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
@@ -51,5 +52,18 @@ class AnimeMapperTests {
     void 引数のidに対したアニメが存在しない時_空のOptionalを取得すること() {
         Optional<Anime> anime = animeMapper.findById(3);
         assertThat(anime).isEmpty();
+    }
+
+    @Test
+    @DataSet(value = "anime.yml")
+    @ExpectedDataSet(value = "expectedAfterInsertAnime.yml", ignoreCols = "id")
+    void アニメが登録できること() {
+        Anime anime = new Anime("Anime3", "Power");
+        assertThat(anime.getId()).isNull();
+        animeMapper.createAnime(anime);
+        assertThat(anime.getId()).isNotNull();
+        assertThat(anime.getId()).isGreaterThan(2);
+        assertThat(anime.getName()).isEqualTo("Anime3");
+        assertThat(anime.getGenre()).isEqualTo("Power");
     }
 }

--- a/src/test/resources/datasets/expectedAfterInsertAnime.yml
+++ b/src/test/resources/datasets/expectedAfterInsertAnime.yml
@@ -1,0 +1,12 @@
+anime:
+  - id: 1
+    name: "Anime1"
+    genre: "Action"
+
+  - id: 2
+    name: "Anime2"
+    genre: "Adventure"
+
+  - id: 3
+    name: "Anime3"
+    genre: "Power"


### PR DESCRIPTION
### チケットのURL
[Mapperのテスト[create]](https://trello.com/c/fADrPbul/679-mapper%E3%81%AE%E3%83%86%E3%82%B9%E3%83%88create)
[AnimeMapperの登録メソッド実行時に新しく採番されたIDが取得できるように修正する](https://trello.com/c/n7hHZ6Mz/668-animemapper%E3%81%AE%E7%99%BB%E9%8C%B2%E3%83%A1%E3%82%BD%E3%83%83%E3%83%89%E5%AE%9F%E8%A1%8C%E6%99%82%E3%81%AB%E6%96%B0%E3%81%97%E3%81%8F%E6%8E%A1%E7%95%AA%E3%81%95%E3%82%8C%E3%81%9Fid%E3%81%8C%E5%8F%96%E5%BE%97%E3%81%A7%E3%81%8D%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E4%BF%AE%E6%AD%A3%E3%81%99%E3%82%8B)


### 対応内容
- アニメの登録に対するテストケースを追加しました。
- テストケースのメソッド名は日本語で書きました。
- AnimeMapperの登録メソッド実行時に新しく採番されたIDが取得できることを確認してテストをしました。

Coverageレポート
![cov](https://user-images.githubusercontent.com/115441591/203321698-4a8ac42d-49cc-4015-98f7-23600b04f099.png)



### 参考
https://github.com/renangton/task5_crud_read_and_create/blob/f9c6bcea9ed884c8941772705cdcbf5912b82e03/src/test/java/com/crud_read_and_create/mapper/GameMapperTest.java#L31
https://github.com/yoshi-koyama/spring-test-sample/blob/1a94b61f6f1a800b690ec6f96b21baf6abb51dc5/src/test/java/com/raisetech/springtestsample/repository/mapper/dbrider/UserMapperTest.java#L29
https://github.com/database-rider/database-rider


### セルフチェック
- [x] フォーマットが正しく表示されていること
- [x] 要らないコメントを削除すること
- [x] PRに開発したことを書くこと
- [x] Files Changedを確認して自分が意図していないファイルの差分が表示されていないこと
